### PR TITLE
Using the assertGreaterThan assertion

### DIFF
--- a/tests/AsciiGlobalTest.php
+++ b/tests/AsciiGlobalTest.php
@@ -260,7 +260,7 @@ final class AsciiGlobalTest extends \PHPUnit\Framework\TestCase
 
         // ---
 
-        static::assertTrue(\count($arrayMore) > \count($array));
+        static::assertGreaterThan(\count($array), \count($arrayMore));
     }
 
     public function testFilterFile()


### PR DESCRIPTION
# Changed log

- I think it should be good to use the `assertGreaterThan` to assert the expected and result comparison assertion.