### PR TITLE
Upgrade code to work in PHP8 or greater and/or Laravel 9 or greater

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
             7.4,
             8.0,
             8.1,
+            8.2
         ]
         composer: [basic]
     timeout-minutes: 10
@@ -32,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.17.1
+        uses: shivammathur/setup-php@3
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
@@ -44,7 +45,7 @@ jobs:
         run: echo "::set-output name=directory::$(composer config cache-dir)"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2.1.7
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.directory }}
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@3
+        uses: shivammathur/setup-php@2.17.1
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ If you like a more Object Oriented Way to edit strings, then you can take a look
 
 ```php
 // Portable ASCII
-use voku\helper\ASCII;
+use Voku\Helper\ASCII;
 ASCII::to_transliterate('déjà σσς iıii'); // 'deja sss iiii'
 
-// voku/Stringy
+// Voku/Stringy
 use Stringy\Stringy as S;
 $stringy = S::create('déjà σσς iıii');
 $stringy->toTransliterate();              // 'deja sss iiii'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - cinst -y curl
   - cinst -y OpenSSL.Light
   - SET PATH=C:\Program Files\OpenSSL;%PATH%
-  - cinst -y php --version "7.0.33"
+  - cinst -y php --version "8.0.2"
   - cd C:\tools\php70\ext
   - curl -O https://xdebug.org/files/php_xdebug-2.4.1-7.0-vc14-nts-x86_64.dll
   - cd C:\tools\php70

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0"
+        "php": "^8.0 || ^8.1 || ^8.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
@@ -26,12 +26,12 @@
     },
     "autoload": {
         "psr-4": {
-            "voku\\": "src/voku/"
+            "Voku\\": "src/voku/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "voku\\tests\\": "tests/"
+            "Voku\\Tests\\": "tests/"
         }
     }
 }

--- a/src/voku/helper/ASCII.php
+++ b/src/voku/helper/ASCII.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\helper;
+namespace Voku\Helper;
 
 /**
  * ## 🇷🇺 Русским гражданам

--- a/tests/AsciiGlobalTest.php
+++ b/tests/AsciiGlobalTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace voku\tests;
+namespace Voku\Tests;
 
-use voku\helper\ASCII;
+use Voku\Helper\ASCII;
 
 /**
  * @internal

--- a/tests/AsciiTest.php
+++ b/tests/AsciiTest.php
@@ -190,8 +190,8 @@ final class AsciiTest extends \PHPUnit\Framework\TestCase
 
         static::assertSame('äöüäöüäöü-κόσμεκόσμεäöüäöüäöü κόσμεκόσμεäöüäöüäöü-κόσμεκόσμε', ASCII::remove_invisible_characters("äöüäöüäöü-κόσμεκόσμεäöüäöüäöü\xe1\x9a\x80κόσμεκόσμεäöüäöüäöü-κόσμεκόσμε"));
 
-        static::assertSame('%*ł€! ‎|| ', ASCII::remove_invisible_characters('%*ł€! ‎|| '));
-        static::assertSame('%*ł€! |' . "\n|\t " . "\t", ASCII::remove_invisible_characters('%*ł€! ‎|| ' . "\t", false, '', false));
+        static::assertSame('%*ł€! ‎| | ', ASCII::remove_invisible_characters('%*ł€! ‎| | '));
+        static::assertSame('%*ł€! |' . "\n|\t " . "\t", ASCII::remove_invisible_characters('%*ł€! ‎| | ' . "\t", false, '', false));
 
         static::assertSame('κόσ?με 	%00 | tes%20öäü%20\u00edtest', ASCII::remove_invisible_characters("κόσ\0με 	%00 | tes%20öäü%20\u00edtest", false, '?'));
         static::assertSame('κόσμε 	 | tes%20öäü%20\u00edtest', ASCII::remove_invisible_characters("κόσ\0με 	%00 | tes%20öäü%20\u00edtest", true, ''));

--- a/tests/AsciiTest.php
+++ b/tests/AsciiTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace voku\tests;
+namespace Voku\Tests;
 
-use voku\helper\ASCII;
+use Voku\Helper\ASCII;
 
 /**
  * @internal
@@ -190,8 +190,8 @@ final class AsciiTest extends \PHPUnit\Framework\TestCase
 
         static::assertSame('äöüäöüäöü-κόσμεκόσμεäöüäöüäöü κόσμεκόσμεäöüäöüäöü-κόσμεκόσμε', ASCII::remove_invisible_characters("äöüäöüäöü-κόσμεκόσμεäöüäöüäöü\xe1\x9a\x80κόσμεκόσμεäöüäöüäöü-κόσμεκόσμε"));
 
-        static::assertSame('%*ł€! ‎| | ', ASCII::remove_invisible_characters('%*ł€! ‎| | '));
-        static::assertSame('%*ł€! |' . "\n|\t " . "\t", ASCII::remove_invisible_characters('%*ł€! ‎| | ' . "\t", false, '', false));
+        static::assertSame('%*ł€! ‎|| ', ASCII::remove_invisible_characters('%*ł€! ‎|| '));
+        static::assertSame('%*ł€! |' . "\n|\t " . "\t", ASCII::remove_invisible_characters('%*ł€! ‎|| ' . "\t", false, '', false));
 
         static::assertSame('κόσ?με 	%00 | tes%20öäü%20\u00edtest', ASCII::remove_invisible_characters("κόσ\0με 	%00 | tes%20öäü%20\u00edtest", false, '?'));
         static::assertSame('κόσμε 	 | tes%20öäü%20\u00edtest', ASCII::remove_invisible_characters("κόσ\0με 	%00 | tes%20öäü%20\u00edtest", true, ''));

--- a/tests/TransliterateTest.php
+++ b/tests/TransliterateTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace voku\tests;
+namespace Voku\Tests;
 
-use voku\helper\ASCII;
+use Voku\Helper\ASCII;
 
 /**
  * @internal


### PR DESCRIPTION
Fixes: https://github.com/voku/portable-ascii/issues/86

This repo doesn't work in PHP 8, 8.1 or 8.2 due to the namespaces not being Capitalized.

* Have updated the GitHub workflows up to php 8.2
* Have updated the namespaces.
* Have updated `composer.json` and removed php 7 as security updates ended in 28 November 2022.
* Have updated readme with new namespaces
* Update AppVeyor php test environment from 7.0.33 to 8.0.2

Need to update the connecting repos now.

### Linked to Pull Requests

https://github.com/voku/html-compress-twig/pull/5

https://github.com/voku/HtmlMin/pull/85

https://github.com/voku/simple_html_dom/pull/95

https://github.com/voku/simple-cache/pull/30

https://github.com/voku/portable-ascii/pull/87

### Tested on the following

Tested on PHP 8.2 and Laravel 9.1
