### PR TITLE
Update ASCII.php

### DIFF
--- a/src/voku/helper/ASCII.php
+++ b/src/voku/helper/ASCII.php
@@ -798,7 +798,7 @@ final class ASCII
         bool $remove_unsupported_chars = true,
         bool $replace_extra_symbols = false,
         bool $use_transliterate = false,
-        bool $replace_single_chars_only = null
+        ?bool $replace_single_chars_only = null
     ): string {
         if ($str === '') {
             return '';


### PR DESCRIPTION
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

 php 8.4 : Implicitly marking parameter $replace_single_chars_only as nullable is deprecated, the explicit nullable type must be used instead