### PR TITLE
Fix PHP 8.4 deprecation warning: explicitly declare nullable type for $replace_single_chars_only in to_ascii()

### DIFF
--- a/src/voku/helper/ASCII.php
+++ b/src/voku/helper/ASCII.php
@@ -798,7 +798,7 @@ final class ASCII
         bool $remove_unsupported_chars = true,
         bool $replace_extra_symbols = false,
         bool $use_transliterate = false,
-        bool $replace_single_chars_only = null
+        ?bool $replace_single_chars_only = null
     ): string {
         if ($str === '') {
             return '';


### PR DESCRIPTION
### What
This PR addresses a deprecation warning in PHP 8.4 when the `$replace_single_chars_only` parameter in `voku\helper\ASCII::to_ascii()` is implicitly nullable. 

The parameter has been updated to explicitly declare `?bool` to ensure compatibility with PHP 8.4 and avoid the warning.

### Why
In PHP 8.4, implicit nullable parameters are deprecated. Explicitly marking `$replace_single_chars_only` as `?bool` resolves this issue and maintains compatibility with future PHP versions.

### Changes
- Explicitly declare `?bool` for the `$replace_single_chars_only` parameter in `to_ascii()`.