### PR TITLE
Update ASCII.php for PHP 8.4 compatibility

### DIFF
--- a/src/voku/helper/ASCII.php
+++ b/src/voku/helper/ASCII.php
@@ -775,14 +775,14 @@ final class ASCII
      * @param string    $str                       <p>The input string.</p>
      * @param string    $language                  [optional] <p>Language of the source string.
      *                                             (default is 'en') | ASCII::*_LANGUAGE_CODE</p>
-     * @param bool      $remove_unsupported_chars  [optional] <p>Whether or not to remove the
+     * @param bool      $remove_unsupported_chars  [optional] <p>Whether to remove the
      *                                             unsupported characters.</p>
      * @param bool      $replace_extra_symbols     [optional]  <p>Add some more replacements e.g. "£" with " pound
      *                                             ".</p>
      * @param bool      $use_transliterate         [optional]  <p>Use ASCII::to_transliterate() for unknown chars.</p>
-     * @param bool|null $replace_single_chars_only [optional]  <p>Single char replacement is better for the
-     *                                             performance, but some languages need to replace more then one char
-     *                                             at the same time. | NULL === auto-setting, depended on the
+     * @param bool      $replace_single_chars_only [optional]  <p>Single char replacement is better for the
+     *                                             performance, but some languages need to replace more than one char
+     *                                             at the same time. If FALSE === auto-setting, depended on the
      *                                             language</p>
      *
      * @psalm-pure
@@ -798,7 +798,7 @@ final class ASCII
         bool $remove_unsupported_chars = true,
         bool $replace_extra_symbols = false,
         bool $use_transliterate = false,
-        bool $replace_single_chars_only = null
+        bool $replace_single_chars_only = false
     ): string {
         if ($str === '') {
             return '';


### PR DESCRIPTION
**Fixes** #

php 8.4 : Implicitly marking parameter $replace_single_chars_only as nullable is deprecated, the explicit nullable type must be used instead

#### Proposed Changes
Change NULL for FALSE and update the PHPDocs.
