### PR TITLE
ci: add tests for PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
             8.1,
             8.2,
             8.3,
-            8.4
+            8.4,
+            8.5
         ]
         composer: [basic]
     timeout-minutes: 10
@@ -47,7 +48,7 @@ jobs:
         run: echo "::set-output name=directory::$(composer config cache-dir)"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.3.0
         with:
           path: ${{ steps.composer-cache.outputs.directory }}
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.31.1
+        uses: shivammathur/setup-php@2.36
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug


### PR DESCRIPTION
bump actions/cache
because of https://github.com/voku/portable-ascii/actions/runs/19708279932/job/56461606171#logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI testing to include PHP 8.5.
  * Updated CI build actions for PHP setup and dependency caching to improve reliability.
  * Minor CI configuration formatting cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->