### PR TITLE
Inconsistence between ` to_ascii` calls (since 2.10.0)

### DIFF
--- a/tests/AsciiTest.php
+++ b/tests/AsciiTest.php
@@ -233,6 +233,15 @@ final class AsciiTest extends \PHPUnit\Framework\TestCase
         static::assertSame(\str_repeat('a  b c', 20), ASCII::to_ascii($input, 'en', true), 'with cleanup');
         static::assertSame(\str_repeat('a  b c', 20), ASCII::to_ascii($input, 'en', true), 'with cleanup warm');
     }
+    
+    public function testToAsciiLongCorrectAcrossRepeatedCalls()
+    {
+        $input = 'Webinaire des transitions n°34 - Agir et mobiliser pour la biodiversité dans son entreprise';
+        $output = 'Webinaire des transitions ndeg34 - Agir et mobiliser pour la biodiversite dans son entreprise';
+        
+        static::assertSame($output, ASCII::to_ascii($input, 'en'), 'with cleanup');
+        static::assertSame($output, ASCII::to_ascii($input, 'en'), 'with cleanup warm');
+    }
 
     public function testToAsciiLongEnglishTransliterationShortcutStaysCorrectAcrossRepeatedCalls()
     {


### PR DESCRIPTION
Hello @voku , I've been reproducing an inconsistence between calls of `to_ascii` in my laravel application since 2.10.0. 

Here is a failing test with 2 consecutive calls of `to_ascii`. The first time `°` is converted to `deg`, the second time it is not. In 2.0.3, `°` was always ignored.

I've not looked at why this is happening. There's been some changes for perf purposes in 2.10.0, it seems to be a regression.

Related issue: #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for ASCII transliteration to verify consistent, deterministic output when processing accented text and special characters across repeated operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->